### PR TITLE
made blocks into a react component

### DIFF
--- a/uccw/src/app/page.tsx
+++ b/uccw/src/app/page.tsx
@@ -1,137 +1,19 @@
 'use client';
-import { useEffect } from 'react';
-import Matter, { World } from 'matter-js';
 import Image from 'next/image';
+import Blocks from "@/src/components/page/Blocks";
 
 export default function LandingPage() {
-    var start:boolean = false; //in the future, this should be made a state variable most likely
-                                
-
-    useEffect(() => {
-        
-
-        const height:number = window.innerHeight;
-        const width:number = window.innerWidth;
-
-        console.log("x: "+ width + " y: " + height);
-
-
-        // module aliases
-            const Engine = Matter.Engine,
-                Events = Matter.Events,
-                Render = Matter.Render,
-                Runner = Matter.Runner,
-                Body = Matter.Body,
-                Bodies = Matter.Bodies,
-                Composite = Matter.Composite;
-
-            // create an engine
-            const engine = Engine.create();
-            engine.gravity.scale = .00005;
-
-            // create a renderer
-            const render = Render.create({
-                element: document.body,  //creates canvas element to render to
-                engine: engine,
-                options: {
-                    width,
-                    height,
-                    background: 'transparent',
-                    wireframes: false,
-                }
-            });
-            render.canvas.style.position = 'fixed';
-            render.canvas.style.top = '0';
-            render.canvas.style.left = '0';
-            render.canvas.style.zIndex = '-5';
-
-
-            function spawn() {
-                const randX = Math.random() * innerWidth;
-                const randSize = 20 + Math.random() * 80;
-                const randGrav = Math.random() / 50;
-                const box = Bodies.rectangle(randX, -100, randSize, randSize, {
-                    frictionAir: randGrav,
-                    render: {
-                        sprite: {
-                            texture: '/square.png',
-                            xScale: randSize/ 445,
-                            yScale: randSize / 446,
-                        } 
-                    }});
-                const spin = (Math.random() - 0.5) * 0.4; //goes too fast sometimes but its funny
-                Body.setAngularVelocity(box, spin);
-                Composite.add(engine.world, box);
-            }
-
-            var last = Date.now();
-            
-            window.addEventListener('keydown', (event) => {
-                if (event.key === " ") {
-                    console.log("Space")
-                    event.preventDefault();
-                    start = !start;
-                }
-            });
-
-            Events.on(engine, 'beforeUpdate', () => {
-                if (!start) return;
-                const now = Date.now();
-                if (now - last > 1000) {
-                    spawn();
-                    last = now;
-                }
-            })
-            
-            // run the renderer
-            Render.run(render);
-            // create runner
-            const runner = Runner.create();
-            // run the engine
-            Runner.run(runner, engine);
-
-
-            //maybe use setposition to bring back to top? itd be less random.
-            Events.on(engine, 'afterUpdate', () => {
-                const bodies = Composite.allBodies(engine.world);
-                for (const body of bodies) {
-                    const {x, y} = body.position;
-                    if (y > height + 1000) {
-                        World.remove(engine.world, body);
-                        console.log("DELETED");
-                    }}
-            });
-
-            window.addEventListener("resize", (handleResize))
-            function handleResize() {
-                render.canvas.width = window.innerWidth;
-                render.canvas.height = window.innerHeight;
-                render.options.height = window.innerHeight;
-                render.options.width = window.innerWidth;
-                Render.lookAt(render, {
-                    min: {x: 0, y: 0},
-                    max: {x: innerWidth, y: innerHeight},
-                })
-            }
     
-    return () => {
-        
-        Render.stop(render);
-        Runner.stop(runner);
-        render.canvas.remove();
-        
-    };
-
-
-    });
 
     return (
-        <div className="select-none">
+        
+        <div className="select-none overflow-hidden">
+            <Blocks/>
             <div className="flex items-center justify-around px-10 py-30">
-                <div className="max-w-2xl z-10">
-                    <h1 className='font-extrabold text-5xl text-white text-balance leading-relaxed drop-shadow-lg/50 select-none'>University of Nebraska Lincoln Coding Club (WIP)</h1>
+                <div className="max-w-2xl z-10 ">
+                    <h1 className='font-extrabold text-5xl text-white text-balance leading-relaxed drop-shadow-lg/50 select-none'>University of Nebraska Lincoln Coding Club</h1>
                 </div>
-                <div className="drop-shadow-2xl/25 drop-shadow-white -z-10">
+                <div className="drop-shadow-2xl/25 drop-shadow-white z-10">
                     <Image 
                     src='/landinglogotest.png' 
                     alt='Logo'
@@ -142,9 +24,9 @@ export default function LandingPage() {
             </div>
             {/*top block*/}
             <div className="absolute w-screen h-1/8 top-0 left-0 -z-1 bg-bg-primary"></div>
-            {!start &&<div className="fixed flex bottom-5 left-1/2 transform -translate-x-1/2  items-center text-xl text-white">
-                <p>press space to start</p>
-            </div>}
+
+            
+            
         </div>
     )
 

--- a/uccw/src/app/subclubs/page.tsx
+++ b/uccw/src/app/subclubs/page.tsx
@@ -1,5 +1,10 @@
+import Blocks from "@/src/components/page/Blocks";
+
 export default function Home() {
   return (
-    <p>waddup world!</p>
+    <div>
+      <Blocks/>
+
+    </div>
   );
 }

--- a/uccw/src/components/header/Header.tsx
+++ b/uccw/src/components/header/Header.tsx
@@ -5,12 +5,16 @@ import RightLinks from "./RightLinks";
 export default function Header() {
 
   return (
-    <div className='flex flex-row justify-center'>
-      <div className='flex flex-row items-center justify-evenly px-10 my-2 w-full max-w-[1100px] h-1/5 min-h-[65px] bg-bg-primary'>
-        <LeftLinks />
-        <Logo />
-        <RightLinks />
+    <div>
+      <div className='flex flex-row justify-center'>
+        <div className='flex flex-row items-center justify-evenly px-10 my-2 w-full max-w-[1100px] h-1/5 min-h-[65px] bg-bg-primary'>
+        
+          <LeftLinks />
+          <Logo />
+          <RightLinks />
+        </div>
       </div>
+      
     </div>
   );
 }

--- a/uccw/src/components/page/Blocks.tsx
+++ b/uccw/src/components/page/Blocks.tsx
@@ -1,0 +1,135 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import Matter, { World } from 'matter-js';
+
+export default function Blocks() {
+    
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+
+        const height:number = window.innerHeight;
+        const width:number = window.innerWidth;
+
+
+        // module aliases
+            const Engine = Matter.Engine,
+                Events = Matter.Events,
+                Render = Matter.Render,
+                Runner = Matter.Runner,
+                Body = Matter.Body,
+                Bodies = Matter.Bodies,
+                Composite = Matter.Composite;
+
+            // create an engine
+            const engine = Engine.create();
+            engine.gravity.scale = 0.00005;
+
+            // create a renderer
+            const render = Render.create({
+                element: containerRef.current || undefined,  //creates canvas element to render to
+                engine: engine,
+                options: {
+                    width,
+                    height,
+                    background: 'transparent',
+                    wireframes: false,
+                }
+            });
+            render.canvas.style.position = 'fixed';
+            render.canvas.style.top = '0';
+            render.canvas.style.left = '0';
+            render.canvas.style.zIndex = '-5';
+            render.canvas.style.pointerEvents = "none";
+
+            //put static box over logo, for bounce.
+            /* const box1 = Bodies.rectangle(500, 600, 200, 200, {isStatic: true,render: {
+                        sprite: {
+                            texture: '/square.png',
+                            xScale: 200/ 445,
+                            yScale: 200/ 446,
+                        } 
+                    }}); 
+
+
+            Composite.add(engine.world, [box1]);*/
+
+            function spawn() {
+                const randX = Math.random() * innerWidth;
+                const randSize = 20 + Math.random() * 80;
+                const randGrav = Math.random() / 50;
+                const box = Bodies.rectangle(randX, -100, randSize, randSize, {
+                    frictionAir: randGrav,
+                    render: {
+                        sprite: {
+                            texture: '/square.png',
+                            xScale: randSize/ 445,
+                            yScale: randSize / 446,
+                        } 
+                    }});
+                const spin = (Math.random() - 0.5) * 0.4; //goes too fast sometimes but its funny
+                Body.setAngularVelocity(box, spin);
+                Composite.add(engine.world, box);
+            }
+
+            var last = Date.now();
+
+            Events.on(engine, 'beforeUpdate', () => {
+                //if (!start) return;
+                const now = Date.now();
+                if (now - last > 1000) {
+                    spawn();
+                    last = now;
+                }
+            })
+            
+            // run the renderer
+            Render.run(render);
+            // create runner
+            const runner = Runner.create();
+            // run the engine
+            Runner.run(runner, engine);
+
+
+            //maybe use setposition to bring back to top? itd be less random.
+            Events.on(engine, 'afterUpdate', () => {
+                const bodies = Composite.allBodies(engine.world);
+                for (const body of bodies) {
+                    const {x, y} = body.position;
+                    if (y > height + 1000) {
+                        World.remove(engine.world, body);
+                        console.log("DELETED");
+                    }}
+            });
+
+            function handleResize() {
+                render.canvas.width = window.innerWidth;
+                render.canvas.height = window.innerHeight;
+                render.options.height = window.innerHeight;
+                render.options.width = window.innerWidth;
+                Render.lookAt(render, {
+                    min: {x: 0, y: 0},
+                    max: {x: innerWidth, y: innerHeight},
+                })
+            }
+            window.addEventListener("resize", (handleResize))
+
+    
+    return () => {
+        
+        Render.stop(render);
+        Runner.stop(runner);
+        render.canvas.remove();
+        window.removeEventListener("resize", handleResize);
+
+    };
+
+
+    
+    });
+    return (
+        <div ref={containerRef} className='absolute' />
+    )
+
+}
+


### PR DESCRIPTION
look at the copilot summary, this is crazy. i made the blocks into a component so we can use it on all of the pages. also removed the wip stuff

This pull request refactors the landing page and introduces a new reusable `Blocks` component to handle the animated block background using Matter.js. The Matter.js logic is moved out of the landing page and into its own component, which is now used on multiple pages. The changes also include minor UI improvements and cleanup.

### Componentization and Code Organization

* Created a new `Blocks` component in `uccw/src/components/page/Blocks.tsx` to encapsulate the Matter.js block animation logic, making it reusable and improving separation of concerns. The Matter.js code was removed from `uccw/src/app/page.tsx` and moved here. [[1]](diffhunk://#diff-3e086fd2528cc2ae6df81043ccfffde370bf8a429bf312e1ee2ce82176171361R1-R135) [[2]](diffhunk://#diff-6fdf7b8d87c6ab325d2917dfe7289167f2a2b4897f076e7d8b70830187c9ebfeL2-R16)
* Updated the landing page (`uccw/src/app/page.tsx`) and the subclubs page (`uccw/src/app/subclubs/page.tsx`) to use the new `Blocks` component for consistent animated backgrounds. [[1]](diffhunk://#diff-6fdf7b8d87c6ab325d2917dfe7289167f2a2b4897f076e7d8b70830187c9ebfeL2-R16) [[2]](diffhunk://#diff-14a20ecffea11240060a72f80f5cf5ccc645efc697ed570b8c9edbc5e713480cR1-R8)

### UI and Styling Improvements

* Adjusted z-index and overflow settings on the landing page and image container to improve layering and visual appearance.
* Removed the "press space to start" prompt and related logic from the landing page, simplifying user interaction.
* Added a wrapper `<div>` in the `Header` component for improved layout consistency.